### PR TITLE
Improve pure Python performance by an additional 10-20%

### DIFF
--- a/calculateAverage.py
+++ b/calculateAverage.py
@@ -1,5 +1,6 @@
 # time python3 calculateAverage.py
 import os
+from gc import disable as gc_disable, enable as gc_enable
 import multiprocessing as mp
 
 
@@ -63,20 +64,14 @@ def _process_file_chunk(
     result = dict()
     with open(file_name, "rb") as f:
         f.seek(chunk_start)
+        gc_disable()
         for line in f:
             chunk_start += len(line)
             if chunk_start > chunk_end:
                 break
             location, measurement = line.split(b";")
             measurement = float(measurement)
-            if location not in result:
-                result[location] = [
-                    measurement,
-                    measurement,
-                    measurement,
-                    1,
-                ]  # min, max, sum, count
-            else:
+            try:
                 _result = result[location]
                 if measurement < _result[0]:
                     _result[0] = measurement
@@ -84,6 +79,15 @@ def _process_file_chunk(
                     _result[1] = measurement
                 _result[2] += measurement
                 _result[3] += 1
+            except KeyError:
+                result[location] = [
+                    measurement,
+                    measurement,
+                    measurement,
+                    1,
+                ]  # min, max, sum, count
+        
+        gc_enable()
     return result
 
 


### PR DESCRIPTION
1) The overall performance of pure Python code highly depends on the Python interpreter version. There can be up to a 30% difference between different CPython versions. For example, within a range from CPython 3.8 to CPython 3.13, CPython 3.11 on Windows is significantly faster than other versions (for this project). Therefore, choosing the fastest CPython version is an important first step for performance improvement. Unfortunately, you did not specify which Python version is used in the benchmarks.

2) About the proposed changes:
    2.1) The trick with an exception works faster because an exception will be raised only 400 times among 1e9 iterations. In all other cases, we save time by not performing an additional costly hash-map check operation. This provides a performance boost of 5% to 10%.
    2.2) Temporarily turning off the garbage collector saves even more time.