### PR TITLE
fixed createMeasurements.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@
 .DS_Store
 
 # Measurements
-measurements*.csv
+measurements*.txt
 
 # DuckDB files
 *.ddb

--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@
 .DS_Store
 
 # Measurements
-measurements*.txt
+measurements*.csv
 
 # DuckDB files
 *.ddb

--- a/calculateAveragePypy.py
+++ b/calculateAveragePypy.py
@@ -115,7 +115,6 @@ def _process_file_chunk(
                     ]  # min, max, sum, count
 
                 location = None
-
         gc_enable()
     return result
 

--- a/createMeasurements.py
+++ b/createMeasurements.py
@@ -489,8 +489,8 @@ if __name__ == "__main__":
         "--output",
         dest="output",
         type=str,
-        help='Measurement file name (default is "measurements.txt")',
-        default="measurements.txt",
+        help='Measurement file name (default is "measurements.csv")',
+        default="measurements.csv",
     )
     parser.add_argument(
         "-r",

--- a/createMeasurements.py
+++ b/createMeasurements.py
@@ -444,7 +444,7 @@ class CreateMeasurement:
 
     def generate_measurement_file(
             self,
-            file_name: str = "measurements.csv",
+            file_name: str = "measurements.txt",
             records: int = 1_000_000_000,
             sep: str = ";",
             std_dev: float = 10,
@@ -489,8 +489,8 @@ if __name__ == "__main__":
         "--output",
         dest="output",
         type=str,
-        help='Measurement file name (default is "measurements.csv")',
-        default="measurements.csv",
+        help='Measurement file name (default is "measurements.txt")',
+        default="measurements.txt",
     )
     parser.add_argument(
         "-r",

--- a/createMeasurements.py
+++ b/createMeasurements.py
@@ -444,7 +444,7 @@ class CreateMeasurement:
 
     def generate_measurement_file(
             self,
-            file_name: str = "measurements.txt",
+            file_name: str = "measurements.csv",
             records: int = 1_000_000_000,
             sep: str = ";",
             std_dev: float = 10,
@@ -456,7 +456,7 @@ class CreateMeasurement:
         batches = max(records // 10_000_000, 1)
         batch_ends = np.linspace(0, records, batches + 1).astype(int)
 
-        with open(file_name, "w") as f:
+        with open(file_name, "w", encoding="utf-8") as f:
             for i in tqdm(range(batches)):
                 from_, to = batch_ends[i], batch_ends[i + 1]
                 data = self.generate_batch(std_dev, to - from_)


### PR DESCRIPTION
Generating the data failed on Win11 with Python 3.12, with these changes it works.


Previous Error:
`Creating measurement file 'measurements.txt' with 1000000000 measurements...
  0%|                                                                                                                                                                             | 0/100 [00:00<?, ?it/s]C:\projects\one-billion-row-challenge\1brc\createMeasurements.py:463: UserWarning: Polars found a filename. Ensure you pass a path to the file instead of a python file object when possible for best performance.
  data.write_csv(f, separator=sep, float_precision=1, include_header=False, )
  0%|                                                                                                                                                                             | 0/100 [00:00<?, ?it/s] 
Traceback (most recent call last):
  File "C:\projects\one-billion-row-challenge\1brc\createMeasurements.py", line 507, in <module>
    measurement.generate_measurement_file(
  File "C:\projects\one-billion-row-challenge\1brc\createMeasurements.py", line 463, in generate_measurement_file
    data.write_csv(f, separator=sep, float_precision=1, include_header=False, )
  File "C:\projects\one-billion-row-challenge\venv\Lib\site-packages\polars\dataframe\frame.py", line 2696, in write_csv
    self._df.write_csv(
polars.exceptions.InvalidOperationError: file encoding is not UTF-8`