### PR TITLE
Windows 11 - Add utf-8 to file creation

### DIFF
--- a/createMeasurements.py
+++ b/createMeasurements.py
@@ -456,7 +456,7 @@ class CreateMeasurement:
         batches = max(records // 10_000_000, 1)
         batch_ends = np.linspace(0, records, batches + 1).astype(int)
 
-        with open(file_name, "w") as f:
+        with open(file_name, "w", encoding="utf-8") as f:
             for i in tqdm(range(batches)):
                 from_, to = batch_ends[i], batch_ends[i + 1]
                 data = self.generate_batch(std_dev, to - from_)


### PR DESCRIPTION
**Issue**
On Windows 11, the measurement creation script failed on my machine with polars complaining that the file created is not in utf-8 encoding.

**Solution**
Force a utf-8 encoding so that polars can read the file, since it defaults to utf-8.

Error message:
```
C:\Users\_\Documents\1brc\createMeasurements.py:426: DataOrientationWarning: Row orientation inferred during DataFrame construction. Explicitly specify the orientation by passing `orient="row"` to silence this warning.
  stations = pl.DataFrame(STATIONS, ("names", "means"))
Creating measurement file 'myfile.res' with 1,000,000,000 measurements...
  0%|                                                                                          | 0/100 [00:00<?, ?it/s]C:\Users\_\Documents\1brc\createMeasurements.py:463: UserWarning: Polars found a filename. Ensure you pass a path to the file instead of a python file object when possible for best performance.
  data.write_csv(f, separator=sep, float_precision=1, include_header=False)
  0%|                                                                                          | 0/100 [00:00<?, ?it/s]
Traceback (most recent call last):
  File "C:\Users\_\Documents\1brc\createMeasurements.py", line 507, in <module>
    measurement.generate_measurement_file(
  File "C:\Users\_\Documents\1brc\createMeasurements.py", line 463, in generate_measurement_file
    data.write_csv(f, separator=sep, float_precision=1, include_header=False)
  File "C:\Users\_\AppData\Local\Packages\PythonSoftwareFoundation.Python.3.12_qbz5n2kfra8p0\LocalCache\local-packages\Python312\site-packages\polars\dataframe\frame.py", line 2696, in write_csv
    self._df.write_csv(
polars.exceptions.InvalidOperationError: file encoding is not UTF-8
```